### PR TITLE
Pass the `loose` flag to semver.parse() so it handles malformed input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,15 +16,15 @@ function unpad (val) {
 }
 
 exports.pad = function (ver) {
-  var ver = semver.parse(ver)
+  var ver = semver.parse(ver, true)
   ver.shift()
   ver[3] = ver[3] ? ver[3].replace(/-/g, '') : 0
   ver = ver.map(pad)
   ver[4] = (ver[4] ? '_' + (ver[4] || '') : '~')
-  return ver.slice(0, 5).join('!') 
+  return ver.slice(0, 5).join('!')
 }
 
-exports.unpad = function (ver) {  
+exports.unpad = function (ver) {
   var parts = ver.split('!')
   var build = Number(unpad(parts[3]))
   var ver =
@@ -43,7 +43,7 @@ exports.range = function (r) {
   if('>=' == first.substring(0, 2)) {
     obj.start = exports.pad(
       first.substring(2)
-    ) 
+    )
     first = range.shift()
   }
   else if('>' == first[0]) {

--- a/test/pad.js
+++ b/test/pad.js
@@ -45,3 +45,11 @@ test("\ncomparison tests", function (t) {
   t.end()
 })
 
+test("\nmalformed input", function (t) {
+  ["0.6.0dev2", "0.0.01--prototype"].forEach(function (v) {
+    var padded = semver.pad(v)
+    t.ok(padded, 'pad() must parse ' + v)
+  })
+  t.end()
+})
+


### PR DESCRIPTION
fixbuild() might still need to be more flexible, but this single change
addresses dominictarr/npmd#30 (at least, my npmd sync is still chugging
along many minutes later).

Wrote a unit test with a couple of sample malformed version strings.
